### PR TITLE
Update log4j to 2.17 to address CVE-2021-45105

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ def versions = [
         fasterXmlJackson   : '2.12.5',
         sonarPitest        : '0.5',
         mockito            : '3.12.4',
-        log4JVersion       : '2.16.0'
+        log4JVersion       : '2.17.0'
 ]
 sourceSets {
     aat {


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105