### PR TITLE
EM-4912-suppress-vulnerability

### DIFF
--- a/config/owasp/dependency-check-suppressions.xml
+++ b/config/owasp/dependency-check-suppressions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <suppress>
         <notes>
             Awaiting fix as updating to latest available version hasn't resolved this.
@@ -7,4 +7,72 @@
         <cve>CVE-2016-1000027</cve>
         <cve>CVE-2021-37533</cve>
     </suppress>
+    <!--netty vulnerabilities, 4.1.86 cause other vulnerabilities -->
+    <suppress until="2023-03-04">
+        <notes><![CDATA[file name: netty-buffer-4.1.84.Final.jar]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-buffer@.*$</packageUrl>
+        <cve>CVE-2022-41881</cve>
+    </suppress>
+    <suppress until="2023-03-04">
+        <notes><![CDATA[file name: netty-codec-4.1.84.Final.jar]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-codec@.*$</packageUrl>
+        <cve>CVE-2022-41881</cve>
+    </suppress>
+    <suppress until="2023-03-04">
+        <notes><![CDATA[file name: netty-handler-4.1.84.Final.jar]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-handler@.*$</packageUrl>
+        <cve>CVE-2022-41881</cve>
+    </suppress>
+    <suppress until="2023-03-04">
+        <notes><![CDATA[file name: netty-resolver-4.1.84.Final.jar]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-resolver@.*$</packageUrl>
+        <cve>CVE-2022-41881</cve>
+    </suppress>
+    <suppress until="2023-03-04">
+        <notes><![CDATA[file name: netty-codec-http-4.1.84.Final.jar]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-codec\-http@.*$</packageUrl>
+        <cve>CVE-2022-41881</cve>
+    </suppress>
+    <suppress until="2023-03-04">
+        <notes><![CDATA[file name: netty-codec-http2-4.1.84.Final.jar]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-codec\-http2@.*$</packageUrl>
+        <cve>CVE-2022-41881</cve>
+    </suppress>
+    <suppress until="2023-03-04">
+        <notes><![CDATA[file name: netty-common-4.1.84.Final.jar]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-common@.*$</packageUrl>
+        <cve>CVE-2022-41881</cve>
+    </suppress>
+    <suppress until="2023-03-04">
+        <notes><![CDATA[file name: netty-transport-4.1.84.Final.jar]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-transport@.*$</packageUrl>
+        <cve>CVE-2022-41881</cve>
+    </suppress>
+    <suppress until="2023-03-04">
+        <notes><![CDATA[file name: netty-transport-classes-epoll-4.1.84.Final.jar]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-transport\-classes\-epoll@.*$</packageUrl>
+        <cve>CVE-2022-41881</cve>
+    </suppress>
+    <suppress until="2023-03-04">
+        <notes><![CDATA[file name: netty-transport-classes-kqueue-4.1.84.Final.jar]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-transport\-classes\-kqueue@.*$</packageUrl>
+        <cve>CVE-2022-41881</cve>
+    </suppress>
+    <suppress until="2023-03-04">
+        <notes><![CDATA[file name: netty-transport-classes-native-4.1.84.Final.jar]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-transport\-native\-kqueue@.*$</packageUrl>
+        <cve>CVE-2022-41881</cve>
+    </suppress>
+    <suppress until="2023-03-04">
+        <notes><![CDATA[file name: netty-transport-native-epoll-4.1.84.Final.jar]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-transport\-native\-epoll@.*$</packageUrl>
+        <cve>CVE-2022-41881</cve>
+    </suppress>
+    <suppress until="2023-03-04">
+        <notes><![CDATA[file name: netty-transport-native-unix-common-4.1.84.Final.jar]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-transport\-native\-unix\-common@.*$</packageUrl>
+        <cve>CVE-2022-41881</cve>
+    </suppress>
+    <!--netty vulnerabilities -->
+
 </suppressions>


### PR DESCRIPTION
[EM-4912](https://tools.hmcts.net/jira/browse/EM-4912) suppress vulnerability
latest netty jar 4.1.86 cause other vulnerabilities