### PR TITLE
RIA-6979: iac-hearing-bundle-config file fixed

### DIFF
--- a/src/main/resources/bundleconfiguration/iac-hearing-bundle-config.yaml
+++ b/src/main/resources/bundleconfiguration/iac-hearing-bundle-config.yaml
@@ -20,14 +20,6 @@ folders:
     documents:
       - type: documentSet
         property: /legalRepresentativeDocuments
-        filters:
-          - property: /tag
-            value: caseArgument
-      - type: documentSet
-        property: /legalRepresentativeDocuments
-        filters:
-          - property: /tag
-            value: appealSubmission
   - name: Appeal Reasons
     documents:
       - type: documentSet


### PR DESCRIPTION
**Before creating a pull request make sure that:**
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-6979

### Change description ###

We need to update the hearing bundle config file in order to include ALL appellant documents in the hearing bundle

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
